### PR TITLE
패킷 파싱 오류 수정

### DIFF
--- a/custom_components/kocom_wallpad/pywallpad/client.py
+++ b/custom_components/kocom_wallpad/pywallpad/client.py
@@ -97,7 +97,7 @@ class KocomClient:
             if self.packets[:2] == HEADER and self.packets[-2:] == TAILER:
                 packets.append(self.packets)
                 self.packets = bytes()
-            elif len(self.packets) > 21:
+            else:
                 self.packets = self.packets[1:]
 
         return packets


### PR DESCRIPTION
패킷 파싱 부분에 오타로 보이는 부분을 수정하였습니다.

## 배경 / 증상
컴포넌트를 활성화하고난 뒤 시간이 어느정도 지나거나, 월패드 장치들을 빠르게 조작하는 경우, 먹통이 되는 현상이 있었습니다.

기존에 패킷 중간에 잡음이 섞인 이후부터 동작하지 않는 문제가 있었습니다.

## 개선
파싱 함수 내에 잡음을 방지하기 위한 로직에 오타가 있어 보였습니다.

**기존 코드**는 버퍼가 21자리 초과(22자리)한 경우 가장 오래된 바이트를 버리는 로직인데,
그 다음 바이트를 읽게 되면 계속 22바이트가 유지됩니다. **즉, 한번 오류가 발생한 이후부터는 22바이트 단위로 패킷을 읽게됩니다.**

21바이트일 때부터 버림연산을 하여 계속 21바이트를 유지하도록 수정하였습니다.

이 개선 이후, 시간이 오래 지나면 먹통이 되는 현상이 해결되었습니다.